### PR TITLE
ci: add jobs to build and test application

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,45 @@
+name: Go
+on: [push]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.20', '1.21' ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Install dependencies
+        run: go get .
+      - name: Build
+        run: go build ./...
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.55.2
+          args: --timeout=30m --config=.golangci.yml --issues-exit-code=0
+
+  test:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    strategy:
+      matrix:
+        go-version: [ '1.20', '1.21' ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Test with the Go CLI
+        run: go test ./...

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,33 @@
+image: golang:1.21-alpine
+
+stages:
+  - build
+  - test
+
+.update_deps: &update_deps
+  before_script:
+    - apk update && apk upgrade
+    - apk add gcc alpine-sdk
+
+build:
+  <<: *update_deps
+  stage: build
+  script:
+    - go build
+
+lint:
+  <<: *update_deps
+  stage: build
+  allow_failure: true
+  script:
+    - go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+    - golangci-lint run
+
+test:
+  <<: *update_deps
+  needs:
+    - build
+  stage: test
+  script:
+    - go test ./...
+    - go test -cover ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,45 @@
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+
+linters-settings:
+  gofmt:
+    simplify: true
+  goimports:
+    local-prefixes: gitlab.com/pkarakal/ci-demo
+  govet:
+    check-shadowing: true
+    enable-all: true
+    disable:
+      - fieldalignment
+  misspell:
+    locale: US
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - errcheck
+    - gocritic
+    - gofmt
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - revive
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unused
+    - whitespace
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - bodyclose
+        - scopelint # https://github.com/kyoh86/scopelint/issues/4


### PR DESCRIPTION
This adds a very basic CI configuration to build and test the application. The ci uses go 1.21 image to run these jobs. It also run a linting job which, unlike build and test, can fail.