### PR TITLE
ci: add code quality job

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,31 @@
+name: Code Quality
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  code_quality:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.gitlab.com/gitlab-org/ci-cd/codequality:latest
+      env:
+        SOURCE_CODE: ci-demo
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+        - ${{ github.workspace }}:/code
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run code quality checks
+        run: /run.sh /code
+      - name: Archive code quality results
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-quality-report
+          path: gl-code-quality-report.json
+          retention-days: 7

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,8 @@
 image: golang:1.21.3-alpine
 
+include:
+  - template: Code-Quality.gitlab-ci.yml
+
 stages:
   - build
   - test
@@ -91,3 +94,13 @@ docker:version:
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA
   only:
     - branches
+
+code_quality:
+  rules:
+    - if: $CODE_QUALITY_DISABLED
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG
+  artifacts:
+    paths: [gl-code-quality-report.json]


### PR DESCRIPTION
This uses the template given by GitLab to run code quality checks. This job runs on merge requests, master and tags, but doesn't run in branches that are not used in merge requests. This also exports a code quality report so that gitlab can show the status in the merge request view